### PR TITLE
Add CORS policy and configure Bearer Token expiration

### DIFF
--- a/NetPcContacts.Api/Extensions/WebApplicationBuilderExtensions.cs
+++ b/NetPcContacts.Api/Extensions/WebApplicationBuilderExtensions.cs
@@ -37,6 +37,16 @@ namespace NetPcContacts.Api.Extensions
                     }
                 });
             });
+            builder.Services.AddCors(options =>
+            {
+                options.AddPolicy("CorsPolicy", builder =>
+                {
+                    builder.AllowAnyHeader()
+                    .AllowAnyMethod()
+                    .WithOrigins("*")
+                    .AllowCredentials();
+                });
+            });
         }
     }
 }

--- a/NetPcContacts.Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/NetPcContacts.Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -1,11 +1,12 @@
-﻿using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.AspNetCore.Authentication.BearerToken;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using NetPcContacts.Domain.Entities;
 using NetPcContacts.Domain.IRepositories;
 using NetPcContacts.Infrastructure.Persistence;
 using NetPcContacts.Infrastructure.Repositories;
-using Microsoft.AspNetCore.Identity;
-using NetPcContacts.Domain.Entities;
 
 namespace NetPcContacts.Infrastructure.Extensions;
 
@@ -23,6 +24,9 @@ public static class ServiceCollectionExtensions
         services.AddIdentityCore<User>()
             .AddEntityFrameworkStores<NetPcContactsDbContext>()
             .AddApiEndpoints();
+
+        // domyślnie token wygasa po 1h, zmieniamy na 1 min
+        services.ConfigureAll<BearerTokenOptions>(option => option.BearerTokenExpiration = TimeSpan.FromMinutes(1));
 
         // Rejestracja repozytorium
         services.AddScoped<IContactsRepository, ContactsRepository>();


### PR DESCRIPTION
Added a CORS policy in `WebApplicationBuilderExtensions.cs` to allow any header, method, and origins with credentials.

Updated `ServiceCollectionExtensions.cs`:
- Adjusted `using` directives for better organization.
- Added Bearer Token authentication support.
- Configured `BearerTokenOptions` to set token expiration to 1 minute.